### PR TITLE
Update lutris_bulk_adder.py

### DIFF
--- a/lutris_bulk_adder/lutris_bulk_adder.py
+++ b/lutris_bulk_adder/lutris_bulk_adder.py
@@ -200,6 +200,7 @@ Do not write YML files or alter Lutris database, only print data to be written o
         game = re.sub(r"\..*", "", os.path.basename(file))  # Strip extension
         for token in args.strip_filename:
             game = game.replace(token, "")                  # Strip tokens
+        game = re.sub("\(.*?\)|\[.*?\]","",game)            # Strip any textin () or []
         game = re.sub(r"\s+", " ", game).strip(" ")         # Remove excess whitespace
 
         slug = re.sub(r"[^0-9A-Za-z']", " ", game)          # Split on nonword characters


### PR DESCRIPTION
strips text in () or [] brackets so file name can be used as game name for example "Super 8 (USA) (Unl)" becomes "Super 8"